### PR TITLE
Put fallback for completed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ var upload = multer({
 })
 ```
 
+## Setting executePutIfPossible
+
+The optional `executePutIfPossible` option can be used use the `putObjectCommand` API instead of the upload API, when a request has already completed and its content-length was recieved, and the content length is smaller than the default part size of the uploader.
+
 ## Testing
 
 The tests mock all access to S3 and can be run completely offline.

--- a/index.js
+++ b/index.js
@@ -231,7 +231,11 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
               buffers.push(buffer)
             })
             params.Body.on('end', function () {
-              res(Buffer.concat(buffers))
+              if (buffers.length === 1) {
+                res(buffers[0])
+              } else {
+                res(Buffer.concat(buffers))
+              }
             })
           })
           return readBufferPromise.then(function (bodyBuffer) {


### PR DESCRIPTION
This is a ~hack~ workaround, to reduce the API calls difference between aws-sdk v2 and aws-sdk v3 where v2 uses PUT for finished streams, while v3 doesn't.